### PR TITLE
Updated lecture 4 to be OS agnostic

### DIFF
--- a/4-tools/manual.ipynb
+++ b/4-tools/manual.ipynb
@@ -150,7 +150,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%run_pytest[clean] -qq\n",
+    "%%ipytest\n",
     "\n",
     "# The test that reveals the problems\n",
     "def test_square():\n",
@@ -417,7 +417,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -431,7 +431,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/4-tools/presentation.ipynb
+++ b/4-tools/presentation.ipynb
@@ -46,17 +46,11 @@
     "\n",
     "Recall from lecture 1 [The Python Style Guide](https://www.python.org/dev/peps/pep-0008/) a.k.a. PEP8.  \n",
     "\n",
-    "It is a lengthy document that can be hard to memorize. Instead, there are nifty tools one can use to check the PEP8 compliance of a script. Consider for example [pycodestyle](https://pypi.org/project/pycodestyle/). Once it has been installed on your system, you can check a script in the following way:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "os.system('open -a Terminal .')  # Opens a terminal on MacOS"
+    "It is a lengthy document that can be hard to memorize. Instead, there are nifty tools one can use to check the PEP8 compliance of a script. Consider for example [pycodestyle](https://pypi.org/project/pycodestyle/). Once it has been installed on your system, you can check a script with the following command.\n",
+    "\n",
+    "`pycodestyle is_this_pep8.py`\n",
+    "\n",
+    "##### Run in terminal"
    ]
   },
   {
@@ -76,6 +70,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "scrolled": true,
     "slideshow": {
      "slide_type": "-"
     }
@@ -91,6 +86,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "scrolled": true,
     "slideshow": {
      "slide_type": "-"
     }
@@ -263,7 +259,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "%load_ext heat\n",
@@ -389,24 +387,16 @@
    "cell_type": "markdown",
    "metadata": {
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": "skip"
     }
    },
    "source": [
     "# Spyder\n",
-    "Spyder uses `line_profiler` too in the package [spyder-line-profiler](https://github.com/spyder-ide/spyder-line-profiler)\n",
+    "Spyder uses `line_profiler` too in the package [spyder-line-profiler](https://github.com/spyder-ide/spyder-line-profiler) (Seems to be broken for Spyder 5 atm)\n",
     "\n",
-    "A quick demonstration!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "os.popen('spyder spyderexample.py')"
+    "A quick demonstration!\n",
+    "\n",
+    "##### Run in Spyder"
    ]
   },
   {
@@ -420,17 +410,11 @@
     "# Command line\n",
     "When profiling on the command line, I again encourage you to use `line_profiler`. \n",
     "\n",
-    "We will need the command: `kernprof -l -v spyderexample.py`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "os.system('open -a Terminal .')  # Opens a terminal on MacOS"
+    "We will need the following command.\n",
+    "\n",
+    "`kernprof -l -v performance_example.py`\n",
+    "\n",
+    "##### Run in command line"
    ]
   },
   {
@@ -448,7 +432,7 @@
  "metadata": {
   "celltoolbar": "Slideshow",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -462,7 +446,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I did some small changes in the presentation to avoid MacOS specific commands, now it just says to open the terminal.

I also changed one line in the manual about the testing to avoid a deprecation warning. 

I could not get the Spyder line profiler to work. As far as I can tell it does not currently work on the latest version of Spyder. I will keep an eye on it and make final adjustments to the slides/manual next week, in case there are any updates. 